### PR TITLE
Add spawnp implementation

### DIFF
--- a/posix_spawn/_impl.py
+++ b/posix_spawn/_impl.py
@@ -72,7 +72,8 @@ class FileActions(object):
         _check_error(res)
 
 
-def posix_spawn(path, args, env=None, file_actions=None, attributes=None):
+def posix_spawn(path, args, env=None, file_actions=None, attributes=None,
+                search_path=False):
     if not isinstance(path, bytes):
         raise TypeError(
             "path must be bytes not {0}.".format(type(path).__name__))
@@ -97,7 +98,9 @@ def posix_spawn(path, args, env=None, file_actions=None, attributes=None):
     env_list = [ffi.new("char[]", b"=".join([key, value]))
                 for key, value in env.items()] + [ffi.NULL]
 
-    res = lib.posix_spawn(
+    spawn = lib.posix_spawnp if search_path else lib.posix_spawn
+
+    res = spawn(
         pid,
         path,
         file_actions,


### PR DESCRIPTION
Thanks for making this repo! This greatly helped my implementation of `posix_spawn` in something I was working on. I ended up needing to use `posix_spawnp` as well, so I thought I would contribute back in case anyone else needs it.

This adds the optional `search_path` kwarg that utilizes `posix_spawnp`
to search the process's path for the executable.