### PR TITLE
Skip non-ascii encoded env variables

### DIFF
--- a/posix_spawn/_impl.py
+++ b/posix_spawn/_impl.py
@@ -94,8 +94,16 @@ def posix_spawn(path, args, env=None, file_actions=None, attributes=None):
 
     arg_list = [ffi.new("char[]", arg) for arg in args] + [ffi.NULL]
 
-    env_list = [ffi.new("char[]", b"=".join([key, value]))
-                for key, value in env.items()] + [ffi.NULL]
+    env_list = []
+
+    for key, value in env.items():
+        try:
+            env_list.append(ffi.new("char[]", b"=".join([key, value])))
+        except TypeError:
+            # Only include ascii environment variables
+            pass
+
+    env_list = env_list + [ffi.NULL]
 
     res = lib.posix_spawn(
         pid,

--- a/posix_spawn/tests/test_posix_spawn.py
+++ b/posix_spawn/tests/test_posix_spawn.py
@@ -76,6 +76,38 @@ class TestPosixSpawn(object):
         assert exits(pid) == 0
         assert "environment" == envfile.read()
 
+    def test_ascii_env(self):
+            env = {b"unichar": u"\u0a3c", b"myvar": b"isawesome"}
+            fa = FileActions()
+            pid = posix_spawn(
+                executable,
+                [executable,
+                b'-c',
+                textwrap.dedent("""
+                import os
+                assert os.environ['myvar'] == 'isawesome'
+                """).encode('ascii')],
+                env=env,
+                file_actions=fa
+            )
+            assert exits(pid) == 0
+
+    def test_non_ascii_env(self):
+            env = {b"unichar": u"\u0a3c", b"myvar": b"isawesome"}
+            fa = FileActions()
+            pid = posix_spawn(
+                executable,
+                [executable,
+                b'-c',
+                textwrap.dedent("""
+                import os
+                os.environ['unichar']
+                """).encode('ascii')],
+                env=env,
+                file_actions=fa
+            )
+            assert exits(pid) == 1
+
 
 class TestFileActions(object):
     def test_empty_actions(self):


### PR DESCRIPTION
Using this with Celery, I ran into issues with non-ascii environment variables from Celery (not sure what these are), but they caused a huge issue. This may not be the best way to approach this problem - open to suggestions.
